### PR TITLE
chore: update dependabot configuration to use npm ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: "/api"
+  - package-ecosystem: npm
+    directory: "/"
     schedule:
       interval: monthly
     open-pull-requests-limit: 10


### PR DESCRIPTION
## 変更内容\n\n- package-ecosystemをbundlerからnpmに変更\n- directoryを/apiから/に変更\n\n## 変更理由\n\nプロジェクトの依存関係管理をnpmに統一するため