### PR TITLE
スクレイピングのセレクタを更新してサイト構造変更に対応

### DIFF
--- a/auto-insert/Dockerfile
+++ b/auto-insert/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # 必要な依存関係をインストール
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/auto-insert/scraping.py
+++ b/auto-insert/scraping.py
@@ -51,17 +51,49 @@ def scrape_and_insert(gender: str, gender_id: int):
         soup = BeautifulSoup(html, 'html.parser')
 
         # 必要なデータを抽出
-        names = [element.text for element in soup.find_all('h3', class_='fr-ec-title')]
-        prices = [int(element.text.replace('¥', '').replace(',', '')) for element in soup.find_all('p', class_='fr-ec-price-text')]
-        product_codes = [element.get('id') for element in soup.find_all('a', class_='fr-ec-product-tile')]
-        page_urls = [UNIQLO_DOMAIN + element.get('href') for element in soup.find_all('a', class_='fr-ec-product-tile')]
-        image_urls = [element.get('src') for element in soup.find_all('img', class_='fr-ec-image__img')]
+        products = soup.find_all('a', class_='product-tile__link')
+        
+        names = []
+        prices = []
+        product_codes = []
+        page_urls = []
+        image_urls = []
+        
+        for product in products:
+            # 商品名: 最初の画像のalt属性
+            img = product.find('img', class_='image__img')
+            name = img.get('alt') if img else None
+            names.append(name)
+            
+            # 価格: ¥を含むdivテキスト
+            price_div = product.find('div', string=re.compile(r'¥[0-9,]+'))
+            price = None
+            if price_div:
+                price_text = price_div.get_text().replace('¥', '').replace(',', '')
+                price = int(price_text) if price_text.isdigit() else None
+            prices.append(price)
+            
+            href = product.get('href', '')
+            product_code_match = re.search(r'/products/([^/]+)/\d+', href)
+            product_code = product_code_match.group(1) if product_code_match else None
+            product_codes.append(product_code)
+            
+            # ページURL
+            full_url = UNIQLO_DOMAIN + href if href else None
+            page_urls.append(full_url)
+            
+            # 画像URL: 最初の画像のsrc
+            image_url = img.get('src') if img else None
+            image_urls.append(image_url)
 
         # データの整形とAPIリクエスト
         if len(names) == len(prices) == len(product_codes):
             product_discounts = []
 
             for name, price, product_code, page_url, image_url in zip(names, prices, product_codes, page_urls, image_urls):
+                # Noneの場合はスキップ
+                if not all([name, price, product_code, page_url, image_url]):
+                    continue
                 product_discounts.append({
                     "productCode": product_code,
                     "name": name,
@@ -74,6 +106,10 @@ def scrape_and_insert(gender: str, gender_id: int):
 
             # APIリクエスト
             form = {"productDiscounts": product_discounts}
+
+            # リクエスト内容を出力
+            print("Sending data to API...")
+            print(json.dumps(form, indent=2, ensure_ascii=False))
 
             try:
                 # APIキーをヘッダーに追加


### PR DESCRIPTION
## Summary
- ユニクロのWebサイト構造変更によりスクレイピングが0件になっていた問題を修正
- 新しいHTML構造に対応したセレクタに更新
- 商品データ取得を14件に改善

## 主な変更点
- 商品リンクセレクタ: `fr-ec-product-tile` → `product-tile__link`
- 商品名取得: `h3.fr-ec-title` → 画像の`alt`属性
- 価格取得: `p.fr-ec-price-text` → `¥`を含む`div`要素
- 画像セレクタ: `fr-ec-image__img` → `image__img`
- 商品コード抽出: 汎用的な正規表現パターン`/products/([^/]+)/\d+`に変更
- Dockerfile: Python 3.11 → 3.12 に更新

## Test plan
- [x] Dockerコンテナでスクレイピングテスト実行
- [x] 14件の商品データが正常に取得されることを確認
- [x] product_code形式が既存データと一致することを確認
- [x] 商品名、価格、URL、画像URLが正しく抽出されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)