### PR TITLE
スクレイピング結果が0件の場合にジョブを失敗させる処理を追加

### DIFF
--- a/auto-insert/scraping.py
+++ b/auto-insert/scraping.py
@@ -75,6 +75,11 @@ def scrape_and_insert(gender: str, gender_id: int):
             # APIリクエスト
             form = {"productDiscounts": product_discounts}
 
+            # スクレイピング結果が0件の場合はエラーとして扱う
+            if len(product_discounts) == 0:
+                print("No discount products found. Exiting with error.")
+                sys.exit(1)
+
             try:
                 # APIキーをヘッダーに追加
                 headers = {


### PR DESCRIPTION
## 概要
- スクレイピングで割引商品が0件の場合にGitHub Actionsジョブを失敗させる処理を追加
- `auto-insert/scraping.py` に `sys.exit(1)` によるエラー終了処理を実装

## 変更内容
- スクレイピング結果の商品数をチェックし、0件の場合はエラーメッセージを出力してプロセスを異常終了
- これによりGitHub Actionsのジョブステータスが失敗となり、問題の早期発見が可能

## テスト方法
- [ ] スクレイピングで商品が見つからない場合のテスト
- [ ] GitHub Actionsでジョブが適切に失敗することの確認

🤖 Generated with [Claude Code](https://claude.ai/code)