### PR TITLE
Fix lazy-loaded product images

### DIFF
--- a/auto-insert/scraping.py
+++ b/auto-insert/scraping.py
@@ -82,8 +82,8 @@ def scrape_and_insert(gender: str, gender_id: int):
             full_url = UNIQLO_DOMAIN + href if href else None
             page_urls.append(full_url)
             
-            # 画像URL: 最初の画像のsrc
-            image_url = img.get('src') if img else None
+            # 画像URL: 遅延読み込み時はdata-srcに設定される
+            image_url = (img.get('src') or img.get('data-src')) if img else None
             image_urls.append(image_url)
 
         # データの整形とAPIリクエスト


### PR DESCRIPTION
## Summary
- Read product image URLs from `data-src` when `src` is absent.
- Prevent all products from being skipped when Uniqlo uses lazy-loaded images.

## Root cause
The scraper accepted only `img.src`, while the current product tiles expose their image URL through `data-src`. Men therefore produced an empty payload; women only succeeded incidentally when one image had loaded `src`.

## Validation
- Ran the actual men and women scraper scripts in the same container image used by GitHub Actions.
- Redirected API requests to a temporary mock API (no production write).
- Confirmed 36 products were extracted and sent for men, and 36 for women.
- Ran `python3 -m py_compile auto-insert/scraping.py` and `git diff --check`.