### PR TITLE
Fix duplicate product discount inserts

### DIFF
--- a/app/backend/application/insert-product-discounts-serivce.ts
+++ b/app/backend/application/insert-product-discounts-serivce.ts
@@ -34,7 +34,19 @@ export default class InsertProductDiscountService {
 
 		const productRepository = new ProductRepository(this._db); // TODO: DI使いたい
 
-		const deliveredProductDiscounts: ProductDiscount[] = form.productDiscounts;
+		// 同じ商品コードの色違いはDB上で1商品として扱う
+		const uniqueProductDiscounts = new Map<string, ProductDiscount>();
+		for (const productDiscount of form.productDiscounts) {
+			if (!uniqueProductDiscounts.has(productDiscount.productCode)) {
+				uniqueProductDiscounts.set(
+					productDiscount.productCode,
+					productDiscount,
+				);
+			}
+		}
+		const deliveredProductDiscounts: ProductDiscount[] = Array.from(
+			uniqueProductDiscounts.values(),
+		);
 
 		const deliveredProductCodes = deliveredProductDiscounts.map(
 			product => product.productCode,

--- a/auto-insert/scraping.py
+++ b/auto-insert/scraping.py
@@ -89,10 +89,14 @@ def scrape_and_insert(gender: str, gender_id: int):
         # データの整形とAPIリクエスト
         if len(names) == len(prices) == len(product_codes):
             product_discounts = []
+            added_product_codes = set()
 
             for name, price, product_code, page_url, image_url in zip(names, prices, product_codes, page_urls, image_urls):
                 # Noneの場合はスキップ
                 if not all([name, price, product_code, page_url, image_url]):
+                    continue
+                # 色違いの商品タイルは同じ商品コードを持つため、先頭の1件だけ登録する
+                if product_code in added_product_codes:
                     continue
                 product_discounts.append({
                     "productCode": product_code,
@@ -103,6 +107,7 @@ def scrape_and_insert(gender: str, gender_id: int):
                     "price": price,
                     "date": formatted_date
                 })
+                added_product_codes.add(product_code)
 
             # APIリクエスト
             form = {"productDiscounts": product_discounts}


### PR DESCRIPTION
## Summary
- Deduplicate product discounts by product code in the scraper before sending them to the insert API.
- Add the same defensive normalization in the insert service.

## Root cause
Color variants from the limited-offer page share a product code, while the products table enforces a unique product code. The expanded scraper payload therefore caused the insert API to return HTTP 500.

## Validation
- Ran Daily Insert on this branch after the fix.
- Men, women, and timeline jobs all succeeded: https://github.com/ke-suke0215/clothes-discounts-v3/actions/runs/29629027104
- Ran Python syntax compilation, Prettier, and `git diff --check`.